### PR TITLE
Fix: removed an extra closing brace (}) in the "Resources" section

### DIFF
--- a/lilypad_module.json.tmpl
+++ b/lilypad_module.json.tmpl
@@ -48,7 +48,6 @@
 
       "Outputs": [{ "Name": "outputs", "Path": "/outputs" }],
       "Resources": { "GPU": "0", "CPU": "8", "Memory": "16Gb" },
-      },
 
       "Timeout": 1800,
 


### PR DESCRIPTION
 In the original JSON, there was a closing brace after "Memory": "16Gb" that shouldn't have been there.